### PR TITLE
Changed `onclick` back to `onmousedown`

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,8 +136,8 @@ for (let fart of farts) {
     fart.onended = finishFart;
 }
 
-// TODO: change it to onmousedown (it stopped working after separating button and label)
-clickMe.onclick = () => {
+clickMeWrapper.onmousedown = (e) => {
+    e.preventDefault();
     counter += 1;
     popupText.innerText = counter + "🍑💨";
     fireEvents();


### PR DESCRIPTION
This changes `onclick` back to `onmousedown` by moving the event listener to the button wrapper. The `e.preventDefault()` line is needed to disable text selection. Though, [this](https://github.com/tsoding/button/pull/18) pull already fixes the text selection issue, I decided to include my "fix" anyway.